### PR TITLE
Fix comment typo

### DIFF
--- a/kilo.c
+++ b/kilo.c
@@ -217,7 +217,7 @@ int enableRawMode(int fd) {
     raw.c_oflag &= ~(OPOST);
     /* control modes - set 8 bit chars */
     raw.c_cflag |= (CS8);
-    /* local modes - choing off, canonical off, no extended functions,
+    /* local modes - echoing off, canonical off, no extended functions,
      * no signal chars (^Z,^C) */
     raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
     /* control chars - set return condition: min number of bytes and timer. */


### PR DESCRIPTION
Hello,

Just fixing a typo in the comments "choing" missing the "e".

Cheers,
Mig